### PR TITLE
SSL support for IRC clients

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
     little-plugger (1.1.2)
     logging (1.5.2)
       little-plugger (>= 1.1.2)
+    rake (0.9.2.2)
     rb-fsevent (0.4.3.1)
     thor (0.14.6)
     trollop (1.16.2)
@@ -39,4 +40,5 @@ DEPENDENCIES
   camper_van!
   growl
   guard
+  rake
   rb-fsevent

--- a/bin/camper_van
+++ b/bin/camper_van
@@ -30,7 +30,10 @@ For irc debugging, use the debugging proxy:
 
   opt :log_level, "Log level", :default => "info"
   opt :log_file, "Log file", :short => "f", :type => :string
-  opt :ssl, "Enable SSL"
+  opt :ssl, "Enable SSL for IRC client connections"
+  opt :ssl_private_key, "Path to SSL private key file for IRC client connections, defaults to self-signed", :type => :string
+  opt :ssl_cert, "Path to SSL cert file for IRC client connections, defaults to self-signed", :type => :string
+  opt :ssl_verify_peer, "Verify peers for IRC client connections"
 end
 
 opts = Trollop.with_standard_exception_handling parser do
@@ -56,7 +59,10 @@ else
     ARGV[1] || 6667,
     :log_level => opts[:log_level].to_sym,
     :log_to => opts[:log_file],
-    :ssl => opts[:ssl]
+    :ssl => opts[:ssl],
+    :ssl_private_key => opts[:ssl_private_key],
+    :ssl_cert => opts[:ssl_cert],
+    :ssl_verify_peer => opts[:ssl_verify_peer]
   )
 
 end

--- a/bin/camper_van
+++ b/bin/camper_van
@@ -30,6 +30,7 @@ For irc debugging, use the debugging proxy:
 
   opt :log_level, "Log level", :default => "info"
   opt :log_file, "Log file", :short => "f", :type => :string
+  opt :ssl, "Enable SSL"
 end
 
 opts = Trollop.with_standard_exception_handling parser do
@@ -54,7 +55,8 @@ else
     ARGV[0] || "127.0.0.1",
     ARGV[1] || 6667,
     :log_level => opts[:log_level].to_sym,
-    :log_to => opts[:log_file]
+    :log_to => opts[:log_file],
+    :ssl => opts[:ssl]
   )
 
 end

--- a/camper_van.gemspec
+++ b/camper_van.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency "firering", "~> 1.1.0"
   s.add_dependency "logging", "~> 1.5.1"
   s.add_dependency "trollop", "~> 1.16.2"
+
+  s.add_development_dependency "rake"
 end

--- a/lib/camper_van/server.rb
+++ b/lib/camper_van/server.rb
@@ -7,16 +7,18 @@ module CamperVan
     #
     # bind_address - what address to bind to
     # port         - what port to listen on
-    # log_options  - an optional hash of additional configuration
-    #                options for the logger (see .initialize_logging)
-    def self.run(bind_address="localhost", port=6667, log_options={})
+    # options      - an optional hash of additional configuration
+    #                :log_level - defaults to 'info'
+    #                :log_to - log to filename (string), IO. defaults to STDOUT
+    #                :ssl - use ssl for client connections, defaults to false
+    def self.run(bind_address="localhost", port=6667, options={})
 
-      initialize_logging log_options
+      initialize_logging options
 
       EM.run do
         logger = Logging.logger[self.name]
         logger.info "starting server on #{bind_address}:#{port}"
-        EM.start_server bind_address, port, self
+        EM.start_server bind_address, port, self, options
         trap("INT") do
           logger.info "SIGINT, shutting down"
           EM.stop
@@ -58,6 +60,13 @@ module CamperVan
     # Public: returns the instance of the ircd for this connection
     attr_reader :ircd
 
+    # Public: returns connection options
+    attr_reader :options
+
+    def initialize(options={})
+      @options = options
+    end
+
     # Public callback once a server connection is established.
     #
     # Initializes an IRCD instance for this connection.
@@ -69,6 +78,11 @@ module CamperVan
 
       # start up the IRCD for this connection
       @ircd = IRCD.new(self)
+
+      if options[:ssl]
+        logger.info "starting TLS for #{remote_ip}"
+        start_tls
+      end
     end
 
     # Public: callback for when a line of the protocol has been

--- a/lib/camper_van/server.rb
+++ b/lib/camper_van/server.rb
@@ -11,6 +11,9 @@ module CamperVan
     #                :log_level - defaults to 'info'
     #                :log_to - log to filename (string), IO. defaults to STDOUT
     #                :ssl - use ssl for client connections, defaults to false
+    #                :ssl_private_key - if using ssl, private key file to use, defaults to self-signed
+    #                :ssl_cert - if using ssl, cert file to use, defaults to self-signed
+    #                :ssl_verify_peer - if using ssl, verify client certificates, defaults to false
     def self.run(bind_address="localhost", port=6667, options={})
 
       initialize_logging options

--- a/lib/camper_van/server.rb
+++ b/lib/camper_van/server.rb
@@ -81,7 +81,7 @@ module CamperVan
 
       if options[:ssl]
         logger.info "starting TLS for #{remote_ip}"
-        start_tls
+        start_tls(:cert_chain_file => options[:ssl_cert], :private_key_file => options[:ssl_private_key], :verify_peer => options[:ssl_verify_peer])
       end
     end
 

--- a/spec/camper_van/server_spec.rb
+++ b/spec/camper_van/server_spec.rb
@@ -17,7 +17,7 @@ describe CamperVan::Server do
       @tls_started = false
     end
 
-    def start_tls
+    def start_tls(*)
       @tls_started = true
     end
 


### PR DESCRIPTION
This adds `--ssl` and related options to `camper_van` for enabling SSL on IRC client connections. This lets camper_van be accessed securely when run off one's local machine.

I also added rake to the gemspec as a development dependency so `bundle exec rake` works.
