### PR TITLE
Fix issue where $1 seems to be set to nil

### DIFF
--- a/lib/camper_van/command_parser.rb
+++ b/lib/camper_van/command_parser.rb
@@ -23,13 +23,14 @@ module CamperVan
       args = []
       until line.empty? do
         line =~ /^(\S+)(\s|$)/
-        if $1
-          if $1.start_with?(":")
+        group = $1
+        if group 
+          if group.start_with?(":")
             args << line[1..-1]
             break
           else
-            args << $1
-            line = line[$1.size..-1]
+            args << group 
+            line = line[group.size..-1]
             line = line.sub(/^\s+/,"")
           end
         else


### PR DESCRIPTION
This is a strange on. $1 seemed to be set to nil after the first time you accessed it. Guess the global regexp matching group was reset or something. So I just stored the value in a local buffer and it worked.
