### PR TITLE
Fixes tweet related crashes

### DIFF
--- a/lib/camper_van/channel.rb
+++ b/lib/camper_van/channel.rb
@@ -366,12 +366,7 @@ module CamperVan
           end
 
         when "Tweet"
-          # stringify keys since campfire API is inconsistent about it
-          tweet = stringify_keys(YAML.load(message.body))
-          client.campfire_reply :privmsg, name, channel,
-            "@#{tweet["author_username"]}: #{tweet["message"]}" +
-            " (https://twitter.com/#{tweet["author_username"]}" +
-            "/status/#{tweet["id"]})"
+          client.campfire_reply :privmsg, name, channel, message.body
 
         else
           logger.warn "unknown message #{message.type}: #{message.body}"

--- a/spec/camper_van/channel_spec.rb
+++ b/spec/camper_van/channel_spec.rb
@@ -470,24 +470,8 @@ describe CamperVan::Channel do
     end
 
     it "sends a message containing the tweet url when a user posts a tweet" do
-      body = {
-        "id" => 12345,
-        "author_username" => "aniero",
-        "message" => "hello, twitter",
-        "author_avatar_url" => "http://example.com/url.img"
-      }
-      @channel.map_message_to_irc msg("Tweet", :body => body.to_yaml)
-      @client.sent.last.must_match %r(:joe\S+ PRIVMSG #test .*twitter.com/aniero/status/12345.*)
-    end
-
-    it "sends a message containing the tweet url when a user posts a tweet with symbols" do
-      body = {
-        :id => 12345,
-        :author_username => "aniero",
-        :message => "hello, twitter",
-        :author_avatar_url => "http://example.com/url.img"
-      }
-      @channel.map_message_to_irc msg("Tweet", :body => body.to_yaml)
+      body = "hello world -- @author, twitter.com/aniero/status/12345.*"
+      @channel.map_message_to_irc msg("Tweet", :body => body)
       @client.sent.last.must_match %r(:joe\S+ PRIVMSG #test .*twitter.com/aniero/status/12345.*)
     end
 


### PR DESCRIPTION
There's no reason to treat the message body of a tweet as special.  Let the
user act on it as if it were any message containing a url.
