### PR TITLE
Fix bug seen when channel topic is null

### DIFF
--- a/lib/camper_van/channel.rb
+++ b/lib/camper_van/channel.rb
@@ -56,7 +56,7 @@ module CamperVan
           client.user_reply :join, ":#{channel}"
 
           # current topic
-          client.numeric_reply :rpl_topic, channel, ':' + room.topic
+          client.numeric_reply :rpl_topic, channel, ':' + (room.topic or '')
 
           # List the current users, which must always include myself
           # (race condition, server may not realize the user has joined yet)


### PR DESCRIPTION
When the topic for a channel is null, the process crashes due to TypeError (converting nil to string).  See full stack trace below.

/var/lib/gems/1.9.1/gems/camper_van-0.0.6/lib/camper_van/channel.rb:59:in `+': can't convert nil into String (TypeError)
        from /var/lib/gems/1.9.1/gems/camper_van-0.0.6/lib/camper_van/channel.rb:59:in`block in join'
        from /var/lib/gems/1.9.1/gems/camper_van-0.0.6/lib/camper_van/channel.rb:240:in `call'
        from /var/lib/gems/1.9.1/gems/camper_van-0.0.6/lib/camper_van/channel.rb:240:in`block in update_users'
        from /var/lib/gems/1.9.1/gems/firering-1.2.2/lib/firering/data/room.rb:22:in `call'
        from /var/lib/gems/1.9.1/gems/firering-1.2.2/lib/firering/data/room.rb:22:in`block in users'
        from /var/lib/gems/1.9.1/gems/firering-1.2.2/lib/firering/connection.rb:69:in `call'
        from /var/lib/gems/1.9.1/gems/firering-1.2.2/lib/firering/connection.rb:69:in`block in http'
        from /var/lib/gems/1.9.1/gems/eventmachine-0.12.10/lib/em/deferrable.rb:134:in `call'
        from /var/lib/gems/1.9.1/gems/eventmachine-0.12.10/lib/em/deferrable.rb:134:in`set_deferred_status'
        from /var/lib/gems/1.9.1/gems/eventmachine-0.12.10/lib/em/deferrable.rb:173:in `succeed'
        from /var/lib/gems/1.9.1/gems/em-http-request-0.3.0/lib/em-http/client.rb:307:in`unbind'
        from /var/lib/gems/1.9.1/gems/eventmachine-0.12.10/lib/eventmachine.rb:1417:in `event_callback'
        from /var/lib/gems/1.9.1/gems/eventmachine-0.12.10/lib/eventmachine.rb:256:in`run_machine'
        from /var/lib/gems/1.9.1/gems/eventmachine-0.12.10/lib/eventmachine.rb:256:in `run'
        from /var/lib/gems/1.9.1/gems/camper_van-0.0.6/lib/camper_van/server.rb:21:in`run'
        from /var/lib/gems/1.9.1/gems/camper_van-0.0.6/bin/camper_van:64:in `<top (required)>'
        from /usr/local/bin/camper_van:19:in`load'
        from /usr/local/bin/camper_van:19:in `<main>'
