### PR TITLE
Run camper_van as a daemon

### DIFF
--- a/bin/camper_van
+++ b/bin/camper_van
@@ -41,6 +41,11 @@ Options:
   opt :ssl_private_key, "Path to SSL private key file for IRC client connections, defaults to self-signed", :type => :string
   opt :ssl_cert, "Path to SSL cert file for IRC client connections, defaults to self-signed", :type => :string
   opt :ssl_verify_peer, "Verify peers for IRC client connections"
+
+  opt :daemon, 'Daemonizes the process'
+
+  opt :pid, 'Path of the PID file', :type => :string,
+    :default => '/var/run/camper_van.pid'
 end
 
 opts = Trollop.with_standard_exception_handling parser do
@@ -69,7 +74,9 @@ else
     :ssl => opts[:ssl],
     :ssl_private_key => opts[:ssl_private_key],
     :ssl_cert => opts[:ssl_cert],
-    :ssl_verify_peer => opts[:ssl_verify_peer]
+    :ssl_verify_peer => opts[:ssl_verify_peer],
+    :daemon => opts[:daemon],
+    :pid => opts[:pid]
   )
 
 end

--- a/bin/camper_van
+++ b/bin/camper_van
@@ -36,7 +36,7 @@ Options:
   stop_on "proxy"
 
   opt :log_level, "Log level", :default => "info"
-  opt :log_file, "Log file", :short => "f", :type => :string
+  opt :log_file, "Log file (required when running as a daemon)", :short => "f", :type => :string
   opt :ssl, "Enable SSL for IRC client connections"
   opt :ssl_private_key, "Path to SSL private key file for IRC client connections, defaults to self-signed", :type => :string
   opt :ssl_cert, "Path to SSL cert file for IRC client connections, defaults to self-signed", :type => :string
@@ -52,6 +52,10 @@ opts = Trollop.with_standard_exception_handling parser do
   o = parser.parse ARGV
 
   if (ARGV.first == "proxy" && ARGV.size == 1)
+    raise Trollop::HelpNeeded
+  end
+
+  if o[:daemon] and !o[:log_file]
     raise Trollop::HelpNeeded
   end
 

--- a/lib/camper_van/server.rb
+++ b/lib/camper_van/server.rb
@@ -14,6 +14,8 @@ module CamperVan
     #                :ssl_private_key - if using ssl, private key file to use, defaults to self-signed
     #                :ssl_cert - if using ssl, cert file to use, defaults to self-signed
     #                :ssl_verify_peer - if using ssl, verify client certificates, defaults to false
+    #                :daemon - if camper_van should daemonize itself
+    #                :pid - the path of the PID file to use.
     def self.run(bind_address="localhost", port=6667, options={})
 
       initialize_logging options
@@ -22,10 +24,35 @@ module CamperVan
         logger = Logging.logger[self.name]
         logger.info "starting server on #{bind_address}:#{port}"
         EM.start_server bind_address, port, self, options
+
+        if options[:daemon]
+          daemonize(logger, options[:pid])
+        end
+
         trap("INT") do
           logger.info "SIGINT, shutting down"
           EM.stop
         end
+      end
+    end
+
+    # Turns the current process into a daemon.
+    #
+    # logger - The logger to use
+    # pid - The path to the PID file
+    #
+    def self.daemonize(logger, pid)
+      if !File.writable?(pid)
+        logger.error "The PID file #{pid} is not writable"
+        abort
+      end
+
+      logger.info "Daemonizing camper_van using PID #{pid}"
+
+      Process.daemon
+
+      File.open(pid, 'w') do |handle|
+        handle.write(Process.pid.to_s)
       end
     end
 

--- a/lib/camper_van/server.rb
+++ b/lib/camper_van/server.rb
@@ -54,6 +54,8 @@ module CamperVan
       File.open(pid, 'w') do |handle|
         handle.write(Process.pid.to_s)
       end
+
+      Logging.reopen
     end
 
     # Initialize the logging system


### PR DESCRIPTION
This is a rather crude solution but the easiest one in the way camper_van is
currently set up.

To daemonize a process run camper_van with `-d/--daemon`. A PID file (set to
/var/run/camper_van.pid by default) can be specified using `-i/--pid` (`-p` is
already taken by an SSL related option).

I haven't attached any tests since I'm not really sure on how to test a
daemonized process since said process would also run test related code (due to
`Process.daemon` forking the currently running process).
