### PR TITLE
Disconnect from channels when going away, reconnect when back.

### DIFF
--- a/bin/camper_van
+++ b/bin/camper_van
@@ -46,6 +46,8 @@ Options:
 
   opt :pid, 'Path of the PID file', :type => :string,
     :default => '/var/run/camper_van.pid'
+
+  opt :part_on_away, 'Part from channels when going away'
 end
 
 opts = Trollop.with_standard_exception_handling parser do
@@ -80,7 +82,8 @@ else
     :ssl_cert => opts[:ssl_cert],
     :ssl_verify_peer => opts[:ssl_verify_peer],
     :daemon => opts[:daemon],
-    :pid => opts[:pid]
+    :pid => opts[:pid],
+    :part_on_away => opts[:part_on_away]
   )
 
 end

--- a/lib/camper_van/ircd.rb
+++ b/lib/camper_van/ircd.rb
@@ -26,6 +26,9 @@ module CamperVan
     # Set to false when shutting down so extra commands are ignored.
     attr_reader :active
 
+    # Additional options
+    attr_reader :options
+
     MOTD = <<-motd
       Welcome to CamperVan.
       To see what campfire rooms are available to the
@@ -41,12 +44,13 @@ module CamperVan
     # Public: initialize an IRC server connection
     #
     # client - the EM connection representing the IRC client
-    def initialize(client)
+    def initialize(client, options = {})
       @client = client
       @active = true
       @channels = {}
       @away = false
       @saved_channels = nil
+      @options = options
     end
 
     # The campfire client
@@ -245,6 +249,7 @@ module CamperVan
     end
 
     handle :away do |args|
+      next unless options[:part_on_away]
       if @away
         user_reply 305, "You are no longer marked as being away"
         @saved_channels.each do |channel|

--- a/lib/camper_van/ircd.rb
+++ b/lib/camper_van/ircd.rb
@@ -17,7 +17,7 @@ module CamperVan
     attr_reader :subdomain, :api_key
 
     # Information for the connected user
-    attr_reader :nick, :user, :host
+    attr_reader :nick, :user, :host, :away
 
     # A Hash of connected CampfireChannels
     attr_reader :channels

--- a/lib/camper_van/ircd.rb
+++ b/lib/camper_van/ircd.rb
@@ -45,6 +45,8 @@ module CamperVan
       @client = client
       @active = true
       @channels = {}
+      @away = false
+      @saved_channels = nil
     end
 
     # The campfire client
@@ -243,6 +245,20 @@ module CamperVan
     end
 
     handle :away do |args|
+      if @away
+        user_reply 305, "You are no longer marked as being away"
+        @saved_channels.each do |channel|
+          join_channel channel
+        end
+        @saved_channels = nil
+      else
+        user_reply 306, "You have been marked as being away"
+        @saved_channels = channels.keys
+        channels.values.each do |channel|
+          channel.part
+        end
+      end
+      @away = !@away
       # ignore silently, there's no campfire API for this
     end
 

--- a/lib/camper_van/ircd.rb
+++ b/lib/camper_van/ircd.rb
@@ -49,7 +49,7 @@ module CamperVan
       @active = true
       @channels = {}
       @away = false
-      @saved_channels = nil
+      @saved_channels = []
       @options = options
     end
 
@@ -255,7 +255,7 @@ module CamperVan
         @saved_channels.each do |channel|
           join_channel channel
         end
-        @saved_channels = nil
+        @saved_channels = []
       else
         user_reply 306, "You have been marked as being away"
         @saved_channels = channels.keys

--- a/lib/camper_van/ircd.rb
+++ b/lib/camper_van/ircd.rb
@@ -249,22 +249,24 @@ module CamperVan
     end
 
     handle :away do |args|
-      next unless options[:part_on_away]
       if @away
         user_reply 305, "You are no longer marked as being away"
-        @saved_channels.each do |channel|
-          join_channel channel
+        if options[:part_on_away]
+          @saved_channels.each do |channel|
+            join_channel channel
+          end
+          @saved_channels = []
         end
-        @saved_channels = []
       else
         user_reply 306, "You have been marked as being away"
-        @saved_channels = channels.keys
-        channels.values.each do |channel|
-          channel.part
+        if options[:part_on_away]
+          @saved_channels = channels.keys
+          channels.values.each do |channel|
+            channel.part
+          end
         end
       end
       @away = !@away
-      # ignore silently, there's no campfire API for this
     end
 
     handle :quit do |args|

--- a/lib/camper_van/server.rb
+++ b/lib/camper_van/server.rb
@@ -109,7 +109,7 @@ module CamperVan
       @lt2_delimiter = "\r\n"
 
       # start up the IRCD for this connection
-      @ircd = IRCD.new(self)
+      @ircd = IRCD.new(self, options)
 
       if options[:ssl]
         logger.info "starting TLS for #{remote_ip}"

--- a/spec/camper_van/ircd_spec.rb
+++ b/spec/camper_van/ircd_spec.rb
@@ -22,6 +22,7 @@ describe CamperVan::IRCD do
 
   class TestIRCD < CamperVan::IRCD
     attr_writer :campfire
+    attr_writer :away
   end
 
   before :each do
@@ -236,6 +237,55 @@ describe CamperVan::IRCD do
         @server.handle :quit => ["leaving..."]
       end
 
+    end
+
+    context "with an AWAY command" do
+      before :each do
+        # register
+        @server.handle :pass => ["test:1234asdf"]
+        @server.handle :nick => ["nathan"]
+        @server.handle :user => ["nathan", 0, 0, "Nathan"]
+      end
+
+      context "with part_on_away set" do
+        before :each do
+          @server.campfire = Class.new do
+            def rooms
+              yield [
+                OpenStruct.new(:name => "Test"),
+                OpenStruct.new(:name => "Day Job")
+              ]
+            end
+          end.new
+          @connection.sent.clear
+          @server.options[:part_on_away] = true
+          @server.handle :join => ["#test"]
+          @server.channels["#test"].must_be_instance_of CamperVan::Channel
+        end
+
+        it "calls #away while not away" do
+          @server.handle :away => ["bbl..."]
+          @connection.sent.last.must_equal ":nathan!nathan@127.0.0.1 PART #test"
+        end
+      end
+
+      context "without part_on_away set" do
+        it "calls #away while not away" do
+          @server.away = false
+          @server.away.must_equal false
+          @server.handle :away => ["bbl..."]
+          @server.away.must_equal true
+          @connection.sent.last.must_equal ":nathan!nathan@127.0.0.1 306 :You have been marked as being away"
+        end
+
+        it "returns from #away while away" do
+          @server.away = true
+          @server.away.must_equal true
+          @server.handle :away => []
+          @server.away.must_equal false
+          @connection.sent.last.must_equal ":nathan!nathan@127.0.0.1 305 :You are no longer marked as being away"
+        end
+      end
     end
 
   end


### PR DESCRIPTION
This is a rough patch which will part from channels when going away, and rejoin when you return. This is useful for me because I like to hook up CamperVan to my IRC bouncer and be able to simply `/away` once for all of the servers my bouncer connects to.
