### PR TITLE
Fix for validating PID permissions

### DIFF
--- a/lib/camper_van/server.rb
+++ b/lib/camper_van/server.rb
@@ -42,7 +42,7 @@ module CamperVan
     # pid - The path to the PID file
     #
     def self.daemonize(logger, pid)
-      if !File.writable?(pid)
+      if !File.writable?(File.dirname(pid))
         logger.error "The PID file #{pid} is not writable"
         abort
       end


### PR DESCRIPTION
File.writable? will always return false for a non existing file, thus it's
better to check the parent directory to see if we can write a PID file.
