### PR TITLE
Fix for EM/em-http-request close_connection

### DIFF
--- a/lib/camper_van/channel.rb
+++ b/lib/camper_van/channel.rb
@@ -86,7 +86,10 @@ module CamperVan
     # connections: allowing them to time out rather than leaving explicitly.
     def part
       client.user_reply :part, channel
-      # FIXME this doesn't work. Not even on next_tick. EM/em-http-request bug?
+      if stream
+        stream.close if stream.respond_to?('close') # EM/em-http-request gem is installed and uses .close
+        stream.close_connection if stream.respond_to?('close_connection')
+      end
       stream.close_connection if stream
       # room.leave # let the timeout do it rather than being explicit!
     end


### PR DESCRIPTION
If the em-http-request gem is installed, it will take presidence for the HTTP connection over the EventMachine.  It does not have a .close_connection method, but rather a .close and throws an error when closing an IRC client

See:
camper_van issue #40
https://github.com/zerowidth/camper_van/issues/40

em-http-request
https://github.com/igrigorik/em-http-request/blob/master/lib/em-http/http_connection.rb#L172-201
