### PR TITLE
Update gemspec to have looser restrictions on gems

### DIFF
--- a/camper_van.gemspec
+++ b/camper_van.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "> 1.9.2"
 
-  s.add_dependency "eventmachine", "~> 1.0.3"
-  s.add_dependency "firering", "~> 1.3.0"
-  s.add_dependency "logging", "~> 1.5.1"
-  s.add_dependency "trollop", "~> 1.16.2"
+  s.add_dependency "eventmachine", "~> 1.0", ">= 1.0.3"
+  s.add_dependency "firering", "~> 1.3", ">= 1.3.0"
+  s.add_dependency "logging", "~> 1.5", ">= 1.5.1"
+  s.add_dependency "trollop", "~> 1.16", ">= 1.16.2"
 
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
firering and others are being updated, and their updates are not being taken advantage of because of the strict requirements.

Found because of https://github.com/EmmanuelOga/firering/issues/22 and https://github.com/zerowidth/camper_van/issues/52.
