### PR TITLE
Allowing access retriction by subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ connection and use `other_subdomain:other_api_key` for authentication.
 
 If your IRC client (mIRC) doesn't allow `:` in the password, you can use `-`.
 
+Note that you can also provide a list of subdomains to restrict the access to.
+
 ## Development
 
 CamperVan uses:
@@ -82,4 +84,3 @@ MIT, See LICENSE for details.
 ## Contributing
 
 Fork, patch, test, pull request.
-

--- a/bin/camper_van
+++ b/bin/camper_van
@@ -48,6 +48,7 @@ Options:
     :default => '/var/run/camper_van.pid'
 
   opt :part_on_away, 'Part from channels when going away'
+  opt :subdomain, 'Campfire subdomain comma separated list to restrict the access to (optional)', :type => :string
 end
 
 opts = Trollop.with_standard_exception_handling parser do
@@ -83,7 +84,8 @@ else
     :ssl_verify_peer => opts[:ssl_verify_peer],
     :daemon => opts[:daemon],
     :pid => opts[:pid],
-    :part_on_away => opts[:part_on_away]
+    :part_on_away => opts[:part_on_away],
+    :subdomain => opts[:subdomain]
   )
 
 end

--- a/lib/camper_van/ircd.rb
+++ b/lib/camper_van/ircd.rb
@@ -116,7 +116,7 @@ module CamperVan
         @subdomain = subdomain.split(".").first
 
         # if restricted to one subdomain, validate it
-        if !@options[:subdomain].nil? and @options[:subdomain].split(",").index(@subdomain) == nil
+        if !@options[:subdomain].nil? && @options[:subdomain].split(",").index(@subdomain) == nil
           numeric_reply :err_subdomaininvalid, ":domain #{@subdomain} is invalid"
           shutdown
         end

--- a/lib/camper_van/ircd.rb
+++ b/lib/camper_van/ircd.rb
@@ -114,6 +114,12 @@ module CamperVan
 
         # ignore full "mycompany.campfirenow.com" being set as the subdomain
         @subdomain = subdomain.split(".").first
+
+        # if restricted to one subdomain, validate it
+        if !@options[:subdomain].nil? and @options[:subdomain].split(",").index(@subdomain) == nil
+          numeric_reply :err_subdomaininvalid, ":domain #{@subdomain} is invalid"
+          shutdown
+        end
       end
     end
 
@@ -379,4 +385,3 @@ module CamperVan
 
   end
 end
-

--- a/lib/camper_van/server_reply.rb
+++ b/lib/camper_van/server_reply.rb
@@ -45,6 +45,7 @@ module CamperVan
       :err_notonchannel       => "442",
 
       :err_needmoreparams     => "461",
+      :err_subdomaininvalid   => "462",
       :err_passwdmismatch     => "464",
 
       :err_channelisfull      => "471", # room is full


### PR DESCRIPTION
Added a _subdomain_ parameter in order to allow a list of subdomains to be restricted.

This was useful for hosting camper_van and restricting the access.
